### PR TITLE
Make SCSS variables optional

### DIFF
--- a/src/sass/plyr.scss
+++ b/src/sass/plyr.scss
@@ -5,50 +5,50 @@
 // Variables
 // -------------------------------
 // Colors
-$blue:                    #3498DB;
-$gray-dark:               #343f4a;
-$gray:                    #565d64;
-$gray-light:              #cbd0d3;
-$off-white:               #d6dadd;
+$blue:                    #3498DB !default;
+$gray-dark:               #343f4a !default;
+$gray:                    #565d64 !default;
+$gray-light:              #cbd0d3 !default;
+$off-white:               #d6dadd !default;
 
 // Font sizes
-$font-size-small:         14px;
-$font-size-base:          16px;
-$font-size-large:         ceil(($font-size-base * 1.5));
+$font-size-small:         14px !default;
+$font-size-base:          16px !default;
+$font-size-large:         ceil(($font-size-base * 1.5)) !default;
 
 // Controls
-$control-spacing:         10px;
-$controls-bg:             $gray-dark;
-$control-bg-hover:        $blue;
-$control-color:           $gray-light;
-$control-color-inactive:  $gray;
-$control-color-hover:     #fff;
+$control-spacing:         10px !default;
+$controls-bg:             $gray-dark !default;
+$control-bg-hover:        $blue !default;
+$control-color:           $gray-light !default;
+$control-color-inactive:  $gray !default;
+$control-color-hover:     #fff !default;
 
 // Tooltips
-$tooltip-bg:              $controls-bg;
-$tooltip-color:           #fff;
-$tooltip-padding:         $control-spacing;
-$tooltip-arrow-size:      5px;
-$tooltip-radius:          3px;
+$tooltip-bg:              $controls-bg !default;
+$tooltip-color:           #fff !default;
+$tooltip-padding:         $control-spacing !default;
+$tooltip-arrow-size:      5px !default;
+$tooltip-radius:          3px !default;
 
 // Progress
-$progress-bg:             rgba(red($gray), green($gray), blue($gray), .2);
-$progress-playing-bg:     $blue;
-$progress-buffered-bg:    rgba(red($gray), green($gray), blue($gray), .25);
-$progress-loading-size:   40px;
-$progress-loading-bg:     rgba(0,0,0, .15);
+$progress-bg:             rgba(red($gray), green($gray), blue($gray), .2) !default;
+$progress-playing-bg:     $blue !default;
+$progress-buffered-bg:    rgba(red($gray), green($gray), blue($gray), .25) !default;
+$progress-loading-size:   40px !default;
+$progress-loading-bg:     rgba(0,0,0, .15) !default;
 
 // Volume
-$volume-track-height:     6px;
-$volume-track-bg:         $gray;
-$volume-thumb-height:     ($volume-track-height * 2);
-$volume-thumb-width:      ($volume-track-height * 2);
-$volume-thumb-bg:         $control-color;
-$volume-thumb-bg-focus:   $control-bg-hover;
+$volume-track-height:     6px !default;
+$volume-track-bg:         $gray !default;
+$volume-thumb-height:     ($volume-track-height * 2) !default;
+$volume-thumb-width:      ($volume-track-height * 2) !default;
+$volume-thumb-bg:         $control-color !default;
+$volume-thumb-bg-focus:   $control-bg-hover !default;
 
 // Breakpoints
-$bp-control-split:        560px; // When controls split into left/right
-$bp-captions-large:       768px; // When captions jump to the larger font size
+$bp-control-split:        560px !default; // When controls split into left/right
+$bp-captions-large:       768px !default; // When captions jump to the larger font size
 
 // Utility classes & mixins
 // -------------------------------


### PR DESCRIPTION
When I was using this great plugin a couple of weeks ago I stumbled upon a very small but irritating little 'bug'. I am compiling my own CSS file consisting out of multiple plugins and custom SCSS. When compiling and using the plyr.scss source file it's impossible to overwrite the variables without editing the file itself. I needed to adjust the main blue color to green to match the player with the rest of the site. I'm currently `@import`ing the plyr.scss file and overwriting the color in a separate file that I'm loading after the plyr.scss file.

But of course it would be better to be able to overwrite the variables beforehand. So I added `!default` to each variable making it overwritable before the `@import` like so:

```
$blue: #81C3B3;
@import "plyr";
```

Additionally we could also make some of the `classes` and `@mixin`'s optional. So if your project already has a `clearfix` mixin you don't need it again in the plyr.scss file. Same goes for the 'sr-only` class; if you already have it then you don't really need it again since it gets you duplicate selectors. Also the tab-focus and font-smoothing might be two things you want to handle yourself to match the rest of your page. But that should probably be another issue.