### PR TITLE
cancel open requests when destroy is called

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1879,6 +1879,12 @@
             // Clone the media element to remove listeners
             // http://stackoverflow.com/questions/19469881/javascript-remove-all-event-listeners-of-specific-type
             var clone = player.media.cloneNode(true);
+
+            // Cancel open requests
+            player.media.pause();
+            player.media.setAttribute('src','');
+            player.media.load();
+
             player.media.parentNode.replaceChild(clone, player.media);
         }
 


### PR DESCRIPTION
When destroy is called I expected the media to stop playing AND to stop loading data from the server. This is also important if you create multiple instances of a video player from time to time like on a one-pager website.