### PR TITLE
Added API function 'plyr.media.source()' to get media source

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1917,6 +1917,24 @@
                 player.type = tagName;
             }
         
+            // Add common function to retrieve media source
+            player.media.source = function() {
+                if(player.type === "youtube") {
+                    try {
+                        return player.embed.getVideoUrl();
+                    } catch(e) {
+                        return "";
+                    }
+                }
+                else {
+                    /* The following line may fail.
+                     * Not sure whether to bubble exception up or
+                     * return a default value or log to console.
+                     */
+                    return player.media.getElementsByTagName("source")[0].src;
+                }
+            };
+
             // Check for full support
             player.supported = api.supported(player.type);
 


### PR DESCRIPTION
Currently, there is no simple way of acquiring media source.
This commit adds a new API function which allows developers
to acquire the video source regardless of whether the video
is a youtube-embed or HTML5 video.

Future embeds just need their respective URL fetching code added
to this common function.