### PR TITLE
Updated API function 'plyr.source()' to get media source

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -356,10 +356,10 @@ Here's a list of the methods supported:
   </tr>
   <tr>
     <td><code>source(...)</code></td>
-    <td>String or Array</td>
+    <td>String or Array or (null|undefined)</td>
     <td>
-      Set the media source.
-      <br><br> 
+      Get/Set the media source.
+      <br><br>
       <strong>string</strong><br>
       <code>.source("/path/to/video.mp4")</code><br>
       This will set the <code>src</code> attribute on the <code>video</code> or <code>audio</code> element.
@@ -370,6 +370,9 @@ Here's a list of the methods supported:
       <br><br>
       <strong>YouTube</strong><br>
       Currently this API method only accepts a YouTube ID when used with a YouTube player. I will add URL support soon, along with being able to swap between types (e.g. YouTube to Audio or Video and vice versa.)
+      <br><br>
+      <strong> null or undefined </strong><br>
+      Returns the current media source. Works for both native videos and embeds.
     </td>
   </tr>
   <tr>
@@ -504,3 +507,4 @@ Also these links helped created Plyr:
 
 ## Copyright and License
 [The MIT license](license.md).
+

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1716,6 +1716,27 @@
             }
         }
 
+        // Add common function to retrieve media source
+        function _source(args) {
+            // If not null or undefined, parse it
+            if(args !== null && args !== undefined)
+                return _parseSource(args);
+
+            // Return the current source
+
+            /* The following lines inside if/else may fail.
+             * Not sure whether to bubble exception up or
+             * return a default value or log to console.
+             */
+            if(player.type === "youtube") {
+                    return player.embed.getVideoUrl();
+            }
+            else {
+                return player.media.getElementsByTagName("source")[0].src;
+            }
+        };
+
+
         // Update poster
         function _updatePoster(source) {
             if (player.type === 'video') {
@@ -1997,7 +2018,7 @@
             rewind:             _rewind,
             forward:            _forward,
             seek:               _seek,
-            source:             _parseSource,
+            source:             _source,
             poster:             _updatePoster,
             setVolume:          _setVolume,
             togglePlay:         _togglePlay,


### PR DESCRIPTION
Currently, there is no simple way of acquiring media source.
This commit updates the 'source' API function to allow developers
to acquire the video source regardless of whether the video
is a youtube-embed or HTML5 video.

Future embeds just need their respective URL fetching code added
to this common function.