### PR TITLE
Remove global preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "gulp-util": "^3.0.7",
     "run-sequence": "^1.1.5"
   },
-  "scripts": {
-    "preinstall": "npm install -g gulp"
-  },
   "keywords": [
     "HTML5 Video",
     "HTML5 Audio",


### PR DESCRIPTION
There are a lot of systems where the user has no rights to install packages globally. It isn't needed for gulp anyway, since it's installed locally anyway.