### PR TITLE
Get the proper reference to window on initialization.

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -21,7 +21,7 @@
         // Browser globals (root is window)
         root.plyr = factory(root, document);
     }
-}(this, function(window, document) {
+}(typeof window !== 'undefined' ? window : this, function(window, document) {
     'use strict';
     /*global YT,$f*/
 


### PR DESCRIPTION
The previous code assumed that `this` points to the browsers
window object, which is not the case when using a module bundler.

So we check first if `window` has been defined by our bundler before
falling back to `this`.

(taken from jQuery's codebase)