### PR TITLE
In specific cases Plyr fails to initiate YT: YT.Player is not a constructor

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1382,7 +1382,7 @@
                 container.setAttribute('id', id);
 
                 // Setup API
-                if (typeof YT === 'object') {
+                if (typeof YT === 'object' && YT.loaded !== 0) {
                     _youTubeReady(mediaId, container);
                 }
                 else {


### PR DESCRIPTION
In specific cases it can happen Plyr fails to initiate a youtube player, throwing the following exception: YT.Player is not a constructor.

This happens when the YT API has started loading (typeof YT === 'object' && YT.loaded === 0), but is not completely present yet. Plyr should check wether the YT API has completely loaded. So a check was added to wait for YT.loaded === 1.