### PR TITLE
use $plyr-control-icon-size in sass file

### DIFF
--- a/src/scss/plyr.scss
+++ b/src/scss/plyr.scss
@@ -294,8 +294,8 @@
         color: inherit;
 
         svg {
-            width: 18px;
-            height: 18px;
+            width: $plyr-control-icon-size;
+            height: $plyr-control-icon-size;
             display: block;
             fill: currentColor;
         }


### PR DESCRIPTION
seems like the sass file was missed when $plyr-control-icon-size was first created :)