### PR TITLE
Make the player button clickable on small videos

### DIFF
--- a/src/scss/plyr.scss
+++ b/src/scss/plyr.scss
@@ -397,6 +397,7 @@
 }
 .plyr .plyr__play-large {
     display: inline-block;
+    z-index: 1;
 }
 .plyr--audio .plyr__play-large {
     display: none;


### PR DESCRIPTION
If you set the plyr video to width of 300px, the plyr__controls overlays the play centered play button such that you can't click on the play button. Adding a z-index on the plyr .plyr__play-large fixes that.