### PR TITLE
Prefixed appearance:none was missing for Range Input

### DIFF
--- a/src/scss/plyr.scss
+++ b/src/scss/plyr.scss
@@ -60,6 +60,8 @@
         padding: 0; 
         vertical-align: middle;
         
+        -webkit-appearance:none;
+        -moz-appearance:none;
         appearance: none;
         cursor: pointer;
         border: none;


### PR DESCRIPTION
I'm not 100% certain if the `-moz` prefixed line is needed, but without the `-webkit` line I get funky results in Chrome.