### PR TITLE
Fix Vimeo's unload bug

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -537,9 +537,13 @@ Here's a list of the methods supported:
     <td>Set the poster url. This is supported for the <code>video</code> element only.</td>
   </tr>
   <tr>
-    <td><code>destroy()</code></td>
-    <td>&mdash;</td>
-    <td>Destroys the plyr UI and any media event listeners, effectively restoring to the previous state before <code>setup()</code> was called.</td>
+    <td><code>destroy(...)</code></td>
+    <td>Function</td>
+    <td>
+      Destroys the plyr UI and any media event listeners, effectively restoring to the previous state before <code>setup()</code> was called.<br><br>
+
+      The (optional) callback will be called once the DOM has been cleaned up. This will happen asynchronously since some destroy handlers (such as Vimeo's) are async.
+    </td>
   </tr>
   <tr>
     <td><code>restore()</code></td>

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -3063,9 +3063,16 @@
         // Destroy an instance
         // Event listeners are removed when elements are removed
         // http://stackoverflow.com/questions/12528049/if-a-dom-element-is-removed-are-its-listeners-also-removed-from-memory
-        function _destroy() {
+        function _destroy(callback) {
+            var done = function() {
+                if (callback) {
+                  setTimeout(callback);
+                }
+            }
+
             // Bail if the element is not initialized
             if (!plyr.init) {
+                done();
                 return null;
             }
 
@@ -3081,6 +3088,15 @@
             // YouTube
             if (plyr.type === 'youtube') {
                 plyr.embed.destroy();
+                done();
+                return;
+            }
+
+            // Vimeo
+            if (plyr.type === 'vimeo') {
+                return plyr.embed.unload().then(function() {
+                    done();
+                });
                 return;
             }
 
@@ -3100,6 +3116,8 @@
             // http://stackoverflow.com/questions/19469881/javascript-remove-all-event-listeners-of-specific-type
             var clone = plyr.media.cloneNode(true);
             plyr.media.parentNode.replaceChild(clone, plyr.media);
+
+            done();
         }
 
         // Setup a player


### PR DESCRIPTION
Hey,

This is in response to #318. The issue is that, for some reason, Vimeo's player still tries to send message using the iframe when removing the node. The trick is to unload it properly using `.unload()`, waiting until everything has been unloaded, and then remove the node. It is cumbersome, unfortunately.

-------------------

While digging I also tried to fix the destroy method to bring back the original DOM, but this requires more changes that I'm comfortable doing. Both YT and Vimeo are left in somewhat shady states after a `.destroy`. Here's my thought process / investigation:

- I'm assuming that `destroy` and `restore` should go in pair — a `restore` should bring back what has been `destroy`d.
- Plyr changes the actual DOM provided, so the most straightforward way to bring it back to its original state is cloning the node at the start.
- The passed in node gets modified _outside_ of Plyr's `init` method ([here](https://github.com/Selz/plyr/blob/master/src/js/plyr.js#L3415) and [here](https://github.com/Selz/plyr/blob/master/src/js/plyr.js#L3436)). This breaks my assumption that `destroy` and `restore` should go in pair.