### PR TITLE
Fix vimeo embed crashes post initial set

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1556,9 +1556,6 @@
 
         // When embeds are ready
         function _embedReady() {
-            // Store reference to API
-            plyr.container.plyr.embed = plyr.embed;
-
             // Setup the UI if full support
             if (plyr.supported.full) {
                 _setupInterface();
@@ -2756,9 +2753,6 @@
             // Set aria title and iframe title
             config.title = source.title;
             _setTitle();
-
-            // Reset media objects
-            plyr.container.plyr.media = plyr.media;
         }
 
         // Update poster


### PR DESCRIPTION
It works on the first initialization and then crashes on later initializations because the first one ends up being async because [Vimeo's script is not loaded yet](https://github.com/Selz/plyr/blob/master/src/js/plyr.js#L1509-L1521)[1]. In a sync world, `plyr.container.ply` has not yet been set.

Since `plyr.container.plyr` should hold a reference to the `plyr` object, there is no point in referencing the container only to come back to the current instance. Thus, the order of execution doesn't matter anymore.

Fixes #318 

[1] I normally make all possilby-async-code always async, instead of sometimes async / sometimes sync, as it can lead to subtle bugs like this one