### PR TITLE
Add playback speed button

### DIFF
--- a/demo/src/js/main.js
+++ b/demo/src/js/main.js
@@ -20,7 +20,8 @@
         },
         captions: {
             defaultActive:  true
-        }
+        },
+        controls:           ['play-large', 'play', 'speed-up', 'progress', 'current-time', 'mute', 'volume', 'captions', 'fullscreen']
     });
     plyr.loadSprite('dist/demo.svg');
 

--- a/readme.md
+++ b/readme.md
@@ -244,7 +244,7 @@ Note the single quotes encapsulating the JSON and double quotes on the object ke
     <tr>
       <td><code>controls</code></td>
       <td>Array</td>
-      <td><code>['play-large', 'play', 'progress', 'current-time', 'mute', 'volume', 'captions', 'fullscreen']</code></td>
+      <td><code>['play-large', 'play', 'speed-up', 'progress', 'current-time', 'mute', 'volume', 'captions', 'fullscreen']</code></td>
       <td>Toggle which control elements you would like to display when using the default controls html. If you specify a <code>html</code> option, this is redundant. The default value is to display everything.</td>
     </tr>
     <tr>
@@ -382,6 +382,12 @@ Note the single quotes encapsulating the JSON and double quotes on the object ke
       <td>Object</td>
       <td>&mdash;</td>
       <td>Two properties; <code>enabled</code> which toggles if local storage should be enabled (if the browser supports it). The default value is `true`. This enables storing user settings, currently it only stores volume but more will be added later. The second property <code>key</code> is the key used for the local storage. The default is <code>plyr_volume</code> until more settings are stored.</td>
+    </tr>
+    <tr>
+      <td><code>speeds</code></td>
+      <td>Array</td>
+      <td>[1.0, 1.5, 2.0, 0.5]</td>
+      <td>Playback speed list.</td>
     </tr>
   </tbody>
 </table>

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1983,6 +1983,10 @@
 
         // Speed-up
         function _speedup(speed) {
+            if (!_is.array(config.speeds)) {
+                _warn('Invalid speeds format');
+                return;
+            }
             if (!_is.number(speed)) {
                 var index = config.speeds.indexOf(config.currentSpeed);
                 if (index !== -1) {

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -2001,6 +2001,9 @@
             plyr.media.playbackRate = speed;
 
             _updateSpeedupTooltip(speed);
+
+            // Save speed to localStorage
+            _updateStorage({speed: speed});
         }
 
         // Seek to time
@@ -2568,6 +2571,16 @@
             if (event && _inArray(['mouseenter', 'mouseleave'], event.type)) {
                 _toggleClass(plyr.progress.tooltip, visible, (event.type === 'mouseenter'));
             }
+        }
+
+        // Set playback speed
+        function _setSpeedup(speed) {
+            // Load speed from storage or default value
+            if (_is.undefined(speed)) {
+                speed = plyr.storage.speed || config.defaultSpeed;
+            }
+
+            _speedup(speed);
         }
 
         // Update hover tooltip for playback speed changed
@@ -3437,6 +3450,9 @@
             // Set volume
             _setVolume();
             _updateVolume();
+
+            // Set playback speed
+            _setSpeedup();
 
             // Reset time display
             _timeUpdate();

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -42,10 +42,10 @@
         defaultSpeed:           1.0,
         currentSpeed:           1.0,
         speeds:                 [
+            0.5,
             1.0,
             1.5,
-            2.0,
-            0.5
+            2.0
         ],
         duration:               null,
         displayDuration:        true,


### PR DESCRIPTION
New Options:

- defaultSpeed, default 1.0
- currentSpeed, default `localStorage.speed` or `defaultSpeed`
- speeds, Array, default [1.0, 1.5, 2.0, 0.5]

TODO:

- playbackRate supporting detect
- icon svg (using fast-foward)