### PR TITLE
Added logic to parse youtube video id

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -3259,6 +3259,19 @@
             }
         }
 
+        // Taken from https://gist.github.com/takien/4077195
+        function parseYoutubeVideoId(url) {
+            var videoId;
+            url = url.replace(/(>|<)/gi,'').split(/(vi\/|v=|\/v\/|youtu\.be\/|\/embed\/)/);
+            if(url[2] !== undefined) {
+                videoId = url[2].split(/[^0-9a-z_\-]/i);
+                videoId = videoId[0];
+            } else {
+                videoId = url;
+            }
+            return videoId;
+        }
+
         // Setup a player
         function _init() {
             // Bail if the element is initialized
@@ -3286,6 +3299,12 @@
             if (tagName === 'div') {
                 plyr.type     = media.getAttribute('data-type');
                 plyr.embedId  = media.getAttribute('data-video-id');
+
+                switch(plyr.type) {
+                    case 'youtube':
+                        plyr.embedId = parseYoutubeVideoId(plyr.embedId);
+                        break;
+                }
 
                 // Clean up
                 media.removeAttribute('data-type');


### PR DESCRIPTION
This commit is targetted at solving issue #345 and adds functionality to parse youtube video IDs from various types of youtube video URLs.

Other embed types like vimeo/soundcloud can be extended by following a similar structure as implemented in this commit.
### Link to related issue (if applicable)
# 345
### Sumary of proposed changes

Adds code to parse YouTube embed URLs into video IDs within plyr.
Also provides a sample template to implement parsing logic for other embed providers.
### Task list
- [ ] Tested on [supported browsers](https://github.com/Selz/plyr#browser-support)
- [ ] Gulp build completed 
