### PR TITLE
refactor: miss prefix

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -615,6 +615,7 @@
         })();
 
         _fullscreen = {
+            prefix: prefix,
             // Yet again Microsoft awesomeness,
             // Sometimes the prefix is 'ms', sometimes 'MS' to keep you on your toes
             eventType: (prefix === 'ms' ? 'MSFullscreenChange' : prefix + 'fullscreenchange'),


### PR DESCRIPTION
### Link to related issue (if applicable) 

### Sumary of proposed changes 

`fix _fullscreen.prefix` can't work

### Task list

- [x] Tested on [supported browsers](https://github.com/Selz/plyr#browser-support)
- [x] Gulp build completed 
