### PR TITLE
Fix cannot scroll after destroyed

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -3664,6 +3664,9 @@
                 // Replace the container with the original element provided
                 plyr.container.parentNode.replaceChild(original, plyr.container);
 
+                // unbind escape key
+                document.body.style.overflow = '';
+
                 // Event
                 _triggerEvent(original, 'destroyed', true);
             }


### PR DESCRIPTION
### Link to related issue (if applicable) 

### Sumary of proposed changes 

In single page application, switch router when plyr is fullscreen mode, page cannot scroll, because `document.body.style.overflow` is `hidden`

### Task list

- [ ] Tested on [supported browsers](https://github.com/Selz/plyr#browser-support)
- [ ] Gulp build completed 