### PR TITLE
fix: parse webVTT time NaN

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1340,10 +1340,14 @@
                 } else {
                     var tc1 = [],
                         tc2 = [],
-                        seconds;
+                        seconds = 0;
                     tc1 = tc.split(',');
                     tc2 = tc1[0].split(':');
-                    seconds = Math.floor(tc2[0]*60*60) + Math.floor(tc2[1]*60) + Math.floor(tc2[2]);
+
+                    for (var i = 0, len = tc2.length; i < len; i++) {
+                        seconds += Math.floor(tc2[i]*(Math.pow(60, len-(i+1))));
+                    }
+                    
                     return seconds;
                 }
             }


### PR DESCRIPTION
### Link to related issue (if applicable) 

### Sumary of proposed changes 

If VTT time format is `00:00:15.792`, it will be work,
but some VTT time has `00:15.792` format, it can not work.

### Task list

- [ ] Tested on [supported browsers](https://github.com/Selz/plyr#browser-support)
- [ ] Gulp build completed 
