### PR TITLE
allow for setting additional listener for captions

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -3065,7 +3065,7 @@
             }
 
             // Captions
-            _on(plyr.buttons.captions, 'click', _toggleCaptions);
+            _proxyListener(plyr.buttons.captions, 'click', config.listeners.captions, _toggleCaptions);
 
             // Seek tooltip
             _on(plyr.progress.container, 'mouseenter mouseleave mousemove', _updateSeekTooltip);


### PR DESCRIPTION
### Link to related issue (if applicable) 

Here's a dash.js captions-related issue:
https://github.com/Selz/plyr/issues/418

### Summary of proposed changes 

In order for a plugin to listen for a click on the captions button, this pull request uses `_proxyListener` for captions. This is one change which might help in cases where the tech used is dash.js, and it would be nice to be able to set an additional listener for captions in any case.

### Task list

I've tested this on Firefox and Chrome on Linux--which doesn't seem good enough to check the task.
I would gladly complete the Gulp build if there were instructions on how to do so.

- [ ] Tested on [supported browsers](https://github.com/Selz/plyr#browser-support)
- [ ] Gulp build completed 